### PR TITLE
Added nltk.download('punkt_tab') as one of the required NLTK data in …

### DIFF
--- a/simple_ats/__init__.py
+++ b/simple_ats/__init__.py
@@ -16,3 +16,4 @@ else:
 nltk.download('stopwords')
 nltk.download('punkt')
 nltk.download('wordnet')
+nltk.download('punkt_tab')


### PR DESCRIPTION
I was using your collab notebook and came across this error

```
/usr/local/lib/python3.10/dist-packages/sentence_transformers/cross_encoder/CrossEncoder.py:13: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)
  from tqdm.autonotebook import tqdm, trange
[nltk_data] Downloading package stopwords to /root/nltk_data...
[nltk_data]   Unzipping corpora/stopwords.zip.
[nltk_data] Downloading package punkt to /root/nltk_data...
[nltk_data]   Unzipping tokenizers/punkt.zip.
[nltk_data] Downloading package wordnet to /root/nltk_data...
---------------------------------------------------------------------------
LookupError                               Traceback (most recent call last)
[<ipython-input-4-1f47643671a8>](https://localhost:8080/#) in <cell line: 12>()
     10 # Extract and clean experience
     11 experience = ats.extract_experience()
---> 12 ats.clean_experience(experience)
     13 
     14 # Extract and clean skills

7 frames
[/usr/local/lib/python3.10/dist-packages/nltk/data.py](https://localhost:8080/#) in find(resource_name, paths)
    577     sep = "*" * 70
    578     resource_not_found = f"\n{sep}\n{msg}\n{sep}\n"
--> 579     raise LookupError(resource_not_found)
    580 
    581 

LookupError: 
**********************************************************************
  Resource punkt_tab not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('punkt_tab')
  
  For more information see: https://www.nltk.org/data.html

  Attempted to load tokenizers/punkt_tab/english/

  Searched in:
    - '/root/nltk_data'
    - '/usr/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/local/lib/nltk_data'
**********************************************************************
```

I was able to fix this by running:

```
import nltk

nltk.download('punkt_tab')
```

So I added it to the \_\_init\_\_.py file 